### PR TITLE
Switch to back to apt and add missing usage info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ juju relate hpct-slurm-server-operator hpct-xxx-principal-operator
 Assuming a `hpct-slurm-client-operator` has been deployed:
 
 ```
-juju relate
-juju relate 
-juju relate 
+juju relate slurm-server:auth-munge slurm-client:auth-munge
+juju relate slurm-server:slurm-controller slurm-client:slurm-controller
+juju relate slurm-server:slurm-compute slurm-client:slurm-compute
 ```
 
 ## Relations

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,6 +14,5 @@ bases:
 parts:
   charm:
     override-build: |
-      # Vendored packages
-      git --version || apt-get install -y git
+      git --version || apt install -y git
       craftctl default


### PR DESCRIPTION
This pull request is to make the following changes:

* Switch from `apt-get` back to `apt` in `charmcraft.yaml`.
* Fill in some missing info in the usage section of the README.